### PR TITLE
Fix uninstall table-check error and users list filtering for deleted users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+# v1.6.10
+- Fixed unstallation issue where the plugin could not be removed due to a missing database table.
+- Fixed users list page to exclude deleted users and ensure proper pagination.
+
 # v1.6.9
 - Added Spanish language support with a complete translation of 240 strings.
 - Internationalized the report search UI by replacing hardcoded text with language strings.

--- a/settings.php
+++ b/settings.php
@@ -166,7 +166,8 @@ if ($hassiteconfig) {
     );
 
     global $DB;
-    $exists = $DB->record_exists('quizaccess_proctoring_logs', ['deletionprogress' => 0]);
+    $dbman = $DB->get_manager();
+    $exists = $dbman->table_exists('quizaccess_proctoring_logs') && $DB->record_exists('quizaccess_proctoring_logs', ['deletionprogress' => 0]);
     if ($exists) {
         // Add the box containing the delete message and link.
         $settings->add(new admin_setting_description(

--- a/userslist.php
+++ b/userslist.php
@@ -50,12 +50,13 @@ $PAGE->requires->js_call_amd('quizaccess_proctoring/userpic_modal', 'init');
 
 echo $OUTPUT->header();
 
-// Build SQL query with search filtering and exclude guest user.
+// Build SQL query with search filtering, excluding guest and deleted users.
 $params = ['guestuser' => 'guest'];
 $sql = "SELECT u.id, u.firstname, u.lastname, u.email, u.username, u.picture,
             u.firstnamephonetic, u.lastnamephonetic, u.middlename, u.alternatename
         FROM {user} u
-        WHERE u.username != :guestuser";
+    WHERE u.username != :guestuser
+    AND u.deleted = 0";
 
 if (!empty($search) && is_string($search)) {
     $sql .= " AND (u.firstname LIKE :search1 OR u.lastname LIKE :search2 OR
@@ -84,11 +85,12 @@ $sql .= " ORDER BY u.$sortsql $direction";
 // Get user records based on the SQL query.
 $users = $DB->get_records_sql($sql, $params, $perpage * $page, $perpage);
 
-// Count total users based on search filter, excluding guest user.
+// Count total users based on search filter, excluding guest and deleted users.
 if (!empty($search)) {
     $sql = "SELECT COUNT(*)
             FROM {user}
             WHERE username != :guestuser
+            AND deleted = 0
             AND (firstname LIKE :search1
                  OR lastname LIKE :search2
                  OR email LIKE :search3
@@ -96,7 +98,7 @@ if (!empty($search)) {
     $totaluser = $DB->count_records_sql($sql, $params);
 
 } else {
-    $totaluser = $DB->count_records_select('user', "username != :guestuser", $params);
+    $totaluser = $DB->count_records_select('user', "username != :guestuser AND deleted = 0", $params);
 }
 
 // Check if no users were found.

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'quizaccess_proctoring';
-$plugin->release = '1.6.9';
-$plugin->version = 2026032500;
+$plugin->release = '1.6.10';
+$plugin->version = 2026040700;
 $plugin->requires = 2023100900;
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
## Summary
This PR fixes two issues in `quizaccess_proctoring`:
1. Plugin settings could trigger an error during uninstall scenarios when `quizaccess_proctoring_logs` was missing.
2. The proctoring users list included deleted users in query logic, causing inaccurate result sets and pagination counts.

It also bumps the plugin release metadata to `1.6.10` and updates the changelog.

## Changes
- `settings.php`
  - Added a safe table-existence check using `$DB->get_manager()->table_exists('quizaccess_proctoring_logs')` before calling `record_exists()`.
  - This prevents querying a non-existent table.

- `userslist.php`
  - Added `u.deleted = 0` to the main user listing SQL.
  - Added `deleted = 0` to the filtered count SQL.
  - Added `deleted = 0` to the unfiltered `count_records_select()` condition.
  - Updated related inline comments to reflect guest + deleted-user exclusion.

- `version.php`
  - Updated `$plugin->release` from `1.6.9` to `1.6.10`.
  - Updated `$plugin->version` from `2026032500` to `2026040700`.

- `CHANGELOG.md`
  - Added `v1.6.10` notes for uninstall table-check fix and users list pagination/filtering fix.

## Why
- Moodle can attempt to evaluate plugin settings while database objects are in transitional states; querying a dropped/missing table can break uninstall/remove flows.
- Deleted users should not appear in administrative image management lists, and counts must match list filters to ensure correct paging.